### PR TITLE
Code refactor, rendering logic completed, comment cleanup and update

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,8 +28,7 @@
       <p class="lead">A simple calendar app for scheduling your work day</p>
       <p id="currentDay" class="lead"></p>
     </header>
-    <div id="calendar" class="container-lg px-5">
-
+    <div id="calendar" class="container-lg px-5"></div>
     <script src="https://code.jquery.com/jquery-3.4.1.min.js"></script>
     <script
       src="https://cdn.jsdelivr.net/npm/dayjs@1.11.3/dayjs.min.js"

--- a/script.js
+++ b/script.js
@@ -7,14 +7,17 @@ class Timeblock {
 
   hour = Timeblock.config.earliest;
   description = "";
+
   // Template literal that is used to present the timeblock within the DOM
-  template = `<div id="hour-${(this.hour)}" class="row time-block ${(this.timeframe)}">
-  <div class="col-2 col-md-1 hour text-center py-3">${(this.formattedHour)}</div>
-  <textarea class="col-8 col-md-10 description" rows="3">${(this.description)}</textarea>
-  <button class="btn saveBtn col-2 col-md-1" aria-label="save">
-    <i class="fas fa-save" aria-hidden="true"></i>
-  </button>
-</div>`;
+  get template() {
+    return `<div id="hour-${this.hour}" class="row time-block ${this.timeframe}">
+    <div class="col-2 col-md-1 hour text-center py-3">${this.formattedHour}</div>
+    <textarea class="col-8 col-md-10 description" rows="3">${this.description}</textarea>
+    <button class="btn saveBtn col-2 col-md-1" aria-label="save">
+      <i class="fas fa-save" aria-hidden="true"></i>
+    </button>
+  </div>`;
+  };
 
   get formattedHour() {
     if (this.hour > 12) {
@@ -101,21 +104,19 @@ class Calendar {
   static render() {
     const calendarEl = $('#calendar');
     for (const item of Calendar.blocks) {
-      const target = $(`#hour-${item.hour}`);
-
-      if (target) {
+      if (calendarEl.children().is(`#hour-${item.hour}`)) {
+        const target = $(`#hour-${item.hour}`);
         target.children('.hour').text(item.hour.formatted);
         target.children('textarea').val(item.description);
       } else {
-        calendarEl.append(item.description);
+        calendarEl.append(item.template);
       }
     }
   }
 }
 
 // Callback to update the current time shown on the page
-function renderAll() {
-  Calendar.render();
+function renderTime() {
   $('#currentDay').text(dayjs().format('dddd, YYYY-MM-DD HH:mm'));
 }
 
@@ -158,6 +159,6 @@ $(function () {
   // TODO: Add code to display the current date in the header of the page.
     setInterval(clock update, 1000)
   */
-  renderAll();
-  setInterval(renderAll, 1000);
+  renderTime();
+  setInterval(renderTime, 1000);
 });

--- a/script.js
+++ b/script.js
@@ -1,10 +1,12 @@
-
+// Class for individual blocks of time
 class Timeblock {
+  // Static properties
   static config = {
     earliest: 9,
     latest: 17
   };
 
+  // Instance properties
   hour = Timeblock.config.earliest;
   description = "";
 
@@ -19,6 +21,7 @@ class Timeblock {
   </div>`;
   };
 
+  // Getters
   get formattedHour() {
     if (this.hour > 12) {
       // Return hours later than 12:00 in 12-hour notation
@@ -33,7 +36,11 @@ class Timeblock {
   }
 
   get timeframe() {
+    // Obtain the current hour
     const currentHour = dayjs().hour();
+
+    // Identify if in past, present, or future, then return the applicable timeframe.
+    // This will then be used to apply the corresponding class on the Timeblock
     if (currentHour < this.hour) {
       return 'future';
     }
@@ -45,11 +52,14 @@ class Timeblock {
     }
   }
 
+  // Class constructor
   constructor(hour, description = "") {
     try {
+      // Ensure the hour paramater is a number
       if (typeof hour !== 'number') {
         throw "The hour passed wasn't a number.";
       }
+      // Ensure the parameter is within the configured boundaries
       if (hour < Timeblock.config.earliest || hour > Timeblock.config.latest) {
         throw `The hour passed is outside defined bounds.
         Expected: Earliest: ${Timeblock.config.earliest}, Latest: ${Timeblock.config.latest}.
@@ -57,9 +67,12 @@ class Timeblock {
       }
 
     } catch (err) {
+      // Generate an error explaining why the object couldn't be created
       console.error("Unable to create the Timeblock: ", err);
       return undefined;
     }
+
+    // Resolve the parameters
     this.hour = hour;
     this.description = description;
   }
@@ -99,18 +112,32 @@ class Calendar {
     localStorage.setItem("day-planner-calendar", JSON.stringify(Calendar.blocks));
   }
 
-  static render() {
+  static update(event) {
+    // TODO: Callback method to update the Calendar.blocks structure with a new description when saved.
+  }
+
+  static render(delta = false) {
+    // Define the container for the rendering logic
     const calendarEl = $('#calendar');
+
     for (const item of Calendar.blocks) {
+      // Check if there are already children in the DOM that can be manipulated instead of generating a fresh batch
       if (calendarEl.children().is(`#hour-${item.hour}`)) {
         const target = $(`#hour-${item.hour}`);
+
         // Remove any existing classes for timeframe, then add the current one
         target.removeClass(['past', 'present', 'future']).addClass(item.timeframe);
+        if (delta) {
+          // Terminate the method early if set to render deltas only
+          return;
+        }
+
         // Add formatted time to block
         target.children('.hour').text(item.hour.formatted);
         // Add any events if specified
         target.children('textarea').val(item.description);
       } else {
+        // Propagate the container with all time blocks
         calendarEl.append(item.template);
       }
     }
@@ -119,23 +146,25 @@ class Calendar {
 
 // Callback to update the current time shown on the page
 function renderTime() {
+  // Invokes delta render so that only the timeframe updates
+  Calendar.render(true);
   $('#currentDay').text(dayjs().format('dddd, YYYY-MM-DD HH:mm'));
 }
 
 // WHEN I click the save button for that timeblock
 // THEN the text for that event is saved in local storage
-//  This can be part of the event code below
-
-// WHEN I refresh the page
-// THEN the saved events persist
+// This can be part of the event code below
 
 // Wrap all code that interacts with the DOM in a call to jQuery to ensure that
 // the code isn't run until the browser has finished rendering all the elements
 // in the html.
 $(function () {
   // Initialisers
+  // Generate a fresh set of data
   Calendar.init();
+  // Replace if there's data in localstorage
   Calendar.load();
+  // Commit the structure to localstorage (only really applicable to fresh loads)
   Calendar.save();
   // TODO: Add a listener for click events on the save button. This code should
   // use the id in the containing time-block as a key to save the user input in
@@ -143,20 +172,7 @@ $(function () {
   // function? How can DOM traversal be used to get the "hour-x" id of the
   // time-block containing the button that was clicked? How might the id be
   // useful when saving the description in local storage?
-  //
-  // TODO: Add code to apply the past, present, or future class to each time
-  // block by comparing the id to the current hour. HINTS: How can the id
-  // attribute of each time-block be used to conditionally add or remove the
-  // past, present, and future classes? How can Day.js be used to get the
-  // current hour in 24-hour time?
-  //
-  // TODO: Add code to get any user input that was saved in localStorage and sets
-  // the values of the corresponding textarea elements. HINT: How can the id
-  // attribute of each time-block be used to do this?
-  /*
-  // TODO: Add code to display the current date in the header of the page.
-    setInterval(clock update, 1000)
-  */
+
   renderTime();
   setInterval(renderTime, 1000);
 });

--- a/script.js
+++ b/script.js
@@ -1,107 +1,44 @@
-// Callback to update the current time shown on the page
-function renderTime() {
-  $('#currentDay').text(dayjs().format('dddd, YYYY-MM-DD HH:mm'));
-}
-
-class Calendar {
-  // This is the working set for the calendar
-  static set = [];
-
-  static init() {
-    // Clear the set if not already done
-    Calendar.set = [];
-
-    // Generate a clean batch of Timeblocks
-    for (let i = Timeblock.default.earliest; i <= Timeblock.default.latest; i++) {
-      Calendar.set.push(new Timeblock(i));
-    }
-  }
-
-  static load() {
-    // Make sure the calendar's empty first
-    if (!Calendar.set) {
-      // Check if there is anything in localStorage as well
-      if (typeof localStorage.getItem("day-planner-calendar") !== null) {
-        // Parse the localStorage and generate Timeblocks
-        for (const item of (JSON.parse(localStorage.getItem("day-planner-calendar")))) {
-          // Populate the calendar with every block from the localStorage
-          Calendar.set.push(new Timeblock(item.hour.actual, item.description));
-        }
-
-        Calendar.render();
-        return;
-      }
-
-      // If the above check failed, then that means we need a fresh calendar. Call init.
-      Calendar.init();
-      // Render the calendar on the DOM
-      Calendar.render();
-    }
-  }
-
-  static save() {
-    // Package the current calendar in localStorage
-    localStorage.setItem("day-planner-calendar", JSON.stringify(Calendar.set));
-  }
-
-  static render() {
-    const calendarEl = $('#calendar');
-    for (const item of Calendar.set) {
-      // Check if there's already an element for that hour present, return the index if found
-      const domIndex = calendarEl.children.findIndex( a => {a.id === `hour-${item.hour.actual}`} );
-
-      // If an index was returned
-      if (domIndex > -1) {
-        // Update values of that element
-        calendarEl.children(domIndex).$('textarea').text(item.description);
-      }
-      // If there isn't, add the full template literal
-      calendarEl.children().add(item.template);
-    }
-  }
-}
 
 class Timeblock {
-  static default = {
+  static config = {
     earliest: 9,
     latest: 17
   };
 
-  hour = {
-    actual: Timeblock.default.earliest,
-    formatted: () => {
-      if (hour.actual > 12) {
-        // Return hours later than 12:00 in 12-hour notation
-        return `${hour.actual - 12} PM`;
-      }
-      if (hour.actual === 12) {
-        // Return as-is (since otherwise it would become 0 PM)
-        return `${hour.actual} PM`;
-      }
-      // Fallthrough default
-      return `${hour.actual} AM`;
-    }
-  };
+  hour = Timeblock.config.earliest;
   description = "";
   // Template literal that is used to present the timeblock within the DOM
-  template = `<div id="hour-${this.hour.actual}" class="row time-block ${this.timeframe}">
-  <div class="col-2 col-md-1 hour text-center py-3">${this.hour.formatted}</div>
-  <textarea class="col-8 col-md-10 description" rows="3">${this.description}</textarea>
+  template = `<div id="hour-${(this.hour)}" class="row time-block ${(this.timeframe)}">
+  <div class="col-2 col-md-1 hour text-center py-3">${(this.formattedHour)}</div>
+  <textarea class="col-8 col-md-10 description" rows="3">${(this.description)}</textarea>
   <button class="btn saveBtn col-2 col-md-1" aria-label="save">
     <i class="fas fa-save" aria-hidden="true"></i>
   </button>
 </div>`;
 
+  get formattedHour() {
+    if (this.hour > 12) {
+      // Return hours later than 12:00 in 12-hour notation
+      return `${this.hour - 12} PM`;
+    }
+    if (this.hour === 12) {
+      // Return as-is (since otherwise it would become 0 PM)
+      return `${this.hour} PM`;
+    }
+    // Fallthrough config
+    return `${this.hour} AM`;
+  }
+
   get timeframe() {
-    const currentHour = dayjs.hour();
-    if (this.hour.actual > currentHour) {
-      return 'Future';
+    const currentHour = dayjs().hour;
+    if (this.hour > currentHour) {
+      return 'future';
     }
-    if (this.hour.actual === currentHour) {
-      return 'Present';
+    if (this.hour === currentHour) {
+      return 'present';
     }
-    if (this.hour.actual < currentHour) {
-      return 'Past';
+    if (this.hour < currentHour) {
+      return 'past';
     }
 
     return null;
@@ -112,9 +49,9 @@ class Timeblock {
       if (typeof hour !== 'number') {
         throw "The hour passed wasn't a number.";
       }
-      if (hour < Timeblock.default.earliest || hour > Timeblock.default.latest) {
+      if (hour < Timeblock.config.earliest || hour > Timeblock.config.latest) {
         throw `The hour passed is outside defined bounds.
-        Expected: Earliest: ${Timeblock.default.earliest}, Latest: ${Timeblock.default.latest}.
+        Expected: Earliest: ${Timeblock.config.earliest}, Latest: ${Timeblock.config.latest}.
         Received: ${hour}.`;
       }
 
@@ -122,14 +59,69 @@ class Timeblock {
       console.error("Unable to create the Timeblock: ", err);
       return undefined;
     }
-    this.hour.actual = hour;
+    this.hour = hour;
     this.description = description;
   }
 }
 
+class Calendar {
+  // This is the working set for the calendar
+  static blocks = [];
+
+  static init() {
+    // Clear the blocks
+    Calendar.blocks = [];
+
+    // Generate a clean batch of Timeblocks
+    for (let i = Timeblock.config.earliest; i <= Timeblock.config.latest; i++) {
+      Calendar.blocks.push(new Timeblock(i));
+    }
+  }
+
+  static load() {
+    // Check if there is anything in localStorage as well
+    if (localStorage.getItem("day-planner-calendar")) {
+      // Clear the blocks
+      Calendar.blocks = [];
+      // Parse the localStorage and generate Timeblocks
+      for (const item of JSON.parse(localStorage.getItem("day-planner-calendar"))) {
+        // Populate the calendar with every block from the localStorage
+        Calendar.blocks.push(new Timeblock(item.hour, item.description));
+      }
+    }
+    // Render the updated set
+    Calendar.render();
+  }
+
+  static save() {
+    // Package the current calendar in localStorage
+    localStorage.setItem("day-planner-calendar", JSON.stringify(Calendar.blocks, ["hour", "description"]));
+  }
+
+  static render() {
+    const calendarEl = $('#calendar');
+    for (const item of Calendar.blocks) {
+      const target = $(`#hour-${item.hour}`);
+
+      if (target) {
+        target.children('.hour').text(item.hour.formatted);
+        target.children('textarea').val(item.description);
+      } else {
+        calendarEl.append(item.description);
+      }
+    }
+  }
+}
+
+// Callback to update the current time shown on the page
+function renderAll() {
+  Calendar.render();
+  $('#currentDay').text(dayjs().format('dddd, YYYY-MM-DD HH:mm'));
+}
+
 // WHEN I click into a timeblock
 // THEN I can enter an event
-//  This could just be a setter on the time block class
+//  This could just be a blockster on the time block class
 
 // WHEN I click the save button for that timeblock
 // THEN the text for that event is saved in local storage
@@ -142,6 +134,10 @@ class Timeblock {
 // the code isn't run until the browser has finished rendering all the elements
 // in the html.
 $(function () {
+  // Initialisers
+  Calendar.init();
+  Calendar.load();
+  Calendar.save();
   // TODO: Add a listener for click events on the save button. This code should
   // use the id in the containing time-block as a key to save the user input in
   // local storage. HINT: What does `this` reference in the click listener
@@ -155,13 +151,13 @@ $(function () {
   // past, present, and future classes? How can Day.js be used to get the
   // current hour in 24-hour time?
   //
-  // TODO: Add code to get any user input that was saved in localStorage and set
+  // TODO: Add code to get any user input that was saved in localStorage and sets
   // the values of the corresponding textarea elements. HINT: How can the id
   // attribute of each time-block be used to do this?
   /*
   // TODO: Add code to display the current date in the header of the page.
     setInterval(clock update, 1000)
   */
- renderTime();
- setInterval(renderTime, 1000);
+  renderAll();
+  setInterval(renderAll, 1000);
 });

--- a/script.js
+++ b/script.js
@@ -33,18 +33,16 @@ class Timeblock {
   }
 
   get timeframe() {
-    const currentHour = dayjs().hour;
-    if (this.hour > currentHour) {
+    const currentHour = dayjs().hour();
+    if (currentHour < this.hour) {
       return 'future';
     }
-    if (this.hour === currentHour) {
+    if (currentHour === this.hour) {
       return 'present';
     }
-    if (this.hour < currentHour) {
+    if (currentHour > this.hour) {
       return 'past';
     }
-
-    return null;
   }
 
   constructor(hour, description = "") {
@@ -98,7 +96,7 @@ class Calendar {
 
   static save() {
     // Package the current calendar in localStorage
-    localStorage.setItem("day-planner-calendar", JSON.stringify(Calendar.blocks, ["hour", "description"]));
+    localStorage.setItem("day-planner-calendar", JSON.stringify(Calendar.blocks));
   }
 
   static render() {
@@ -106,7 +104,11 @@ class Calendar {
     for (const item of Calendar.blocks) {
       if (calendarEl.children().is(`#hour-${item.hour}`)) {
         const target = $(`#hour-${item.hour}`);
+        // Remove any existing classes for timeframe, then add the current one
+        target.removeClass(['past', 'present', 'future']).addClass(item.timeframe);
+        // Add formatted time to block
         target.children('.hour').text(item.hour.formatted);
+        // Add any events if specified
         target.children('textarea').val(item.description);
       } else {
         calendarEl.append(item.template);
@@ -119,10 +121,6 @@ class Calendar {
 function renderTime() {
   $('#currentDay').text(dayjs().format('dddd, YYYY-MM-DD HH:mm'));
 }
-
-// WHEN I click into a timeblock
-// THEN I can enter an event
-//  This could just be a blockster on the time block class
 
 // WHEN I click the save button for that timeblock
 // THEN the text for that event is saved in local storage


### PR DESCRIPTION
Fixed a number of minor and severe issues found in the code, as well as updated comments. Breakdown below:

## HTML
- Added closing `<div>` tag for the calendar container

## `Calendar` class
 - Rename `Calendar.set` to `Calendar.blocks` to avoid it being overly generic
 - Rendering logic changes
   - Update logic to use jQuery `is()` for detecting pre-existing nodes
   - Implement `delta` flag in the `Calendar.render()` method to enable partial redraw (CSS manipulation only)
       - Primarily for use with the `renderTime()` callback to update classes as hours advance in the day.
   - Separated logic for `Calendar.init()` and `Calendar.load()` for a better separation of concerns.
       - `init()` now used specifically for the first meaningful paint
       - `load()` now used specifically to load stored localStorage data then replace initialised dataset
   - Added placeholder for `Calendar.update()`, to be developed further in the forthcoming event handler branch

## `Timeblock` class
  - Changed `Timeblock.default` to `Timeblock.config` for clearer communication of purpose
  - Added missing parentheses to `dayjs().hour` in the timeframe check (which resulted in it always evaluating to `null` in original code)
      - Also removed `null` default code path from the timeframe check
      - Also changed return values to all lowercase for consistency with CSS class nomenclature
  - Converted `Timeblock.template` to a getter method so that the template literals would always dynamically compile instead of simply rendering the code blocks. Added benefit of removing it from the data stored in `localStorage`, which wasn't necessary.
  - Converted `Timeblock.hour.actual` to `Timeblock.hour` as a Number instead of an object due to similar rendering issues caused by `Timeblock.template`
  - Additionally, split out `Timeblock.hour.formatted` to a getter - `Timeblock.formattedHour`, allows for the same dynamic handling as `Timeblock.template` now has

## General code changes
- Starting jQuery block now comprises of initialiser calls for `Calendar.init()`, `Calendar.load()`, and `Calendar.save()` respectively.
- `renderTime()` callback updated to call `Calendar.render()` with the delta flag for time block CSS updates only.